### PR TITLE
Implement support for using HASSIO_TOKEN for authentication

### DIFF
--- a/MMM-HASS.js
+++ b/MMM-HASS.js
@@ -16,6 +16,7 @@ Module.register('MMM-HASS', {
     port: '8083',
     initialLoadDelay: 1000,
     updateInterval: 60 * 1000, // every 60 seconds
+    hassiotoken: false, // True: OAuth bearer token for API is in environment variable HASSIO_TOKEN (useful when running as a hassio add-on)
   },
 
   // Define required scripts.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ To use this module, add it to the modules array in the `config/config.js` file:
                 host: "your_home_assistant_ip",
                 port: "your_home_assistant_port",
                 apipassword: "your_home_assistant_api_password",
+                hassiotoken: false,
                 https: false,
                 devices: [
                 { deviceLabel: "Exterior",

--- a/node_helper.js
+++ b/node_helper.js
@@ -126,6 +126,9 @@ module.exports = NodeHelper.create({
       method: 'POST',
       json: params
     };
+    if(config.hassiotoken) {
+      post_options.headers = { 'Authorization' : 'Bearer ' + process.env.HASSIO_TOKEN };
+    }
 
     var post_req = request(post_options, function(error, response, body) {
       if(config.debuglogging) {
@@ -165,10 +168,14 @@ module.exports = NodeHelper.create({
       //
       var i;
       for (i in urls) {
-        request({
+        var get_options = {
           url: urls[i],
-          json: true,
-        }, function(error, response, body) {
+          json: true
+        };
+        if(config.hassiotoken) {
+          get_options.headers = { 'Authorization' : 'Bearer ' + process.env.HASSIO_TOKEN };
+        }
+        request(get_options, function(error, response, body) {
           completed_requests++;
           if(config.debuglogging) {
             console.log(error);


### PR DESCRIPTION
From the Home Assistant docs, it seems like api password is deprecated. When running magic mirror as a Hass.io Add-on (e.g., via [sytone/hassio-addons](https://github.com/sytone/hassio-addons)), there is an environment variable (HASSIO_TOKEN) with an access token. This PR adds a configuration flag to use that instead of an api password.