### PR TITLE
Home Assistant Token Update

### DIFF
--- a/MMM-HASS.js
+++ b/MMM-HASS.js
@@ -123,6 +123,11 @@ Module.register('MMM-HASS', {
 		    valueWrapper.innerHTML = '<i class="dimmed ' + self.config.devices[index].deviceReadings[indexValue].icon + '"></i>';
 		  }
 
+		  // add prefix
+		  if (self.config.devices[index].deviceReadings[indexValue].prefix) {
+		    valueWrapper.innerHTML += self.config.devices[index].deviceReadings[indexValue].prefix;
+		  }
+
 		  valueWrapper.innerHTML += value;
 
 		  // add suffix

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ To use this module, add it to the modules array in the `config/config.js` file:
                 host: "your_home_assistant_ip",
                 port: "your_home_assistant_port",
                 apipassword: "your_home_assistant_api_password",
+                token: "your_home_assistant_long-lived_access_token",
                 hassiotoken: false,
                 https: false,
                 devices: [

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ To use this module, add it to the modules array in the `config/config.js` file:
                 devices: [
                 { deviceLabel: "Exterior",
                         deviceReadings: [
-                        { sensor: "sensor.netatmo_outdoor_temperature", icon: "wi wi-thermometer", suffix: "°"},
+                        { sensor: "sensor.netatmo_outdoor_temperature", icon: "wi wi-thermometer", prefix: "", suffix: "°"},
                         { sensor: "sensor.netatmo_outdoor_humidity", icon: "wi wi-humidity", suffix: "%"},
                         { sensor: "sensor.netatmo_outdoor_battery", icon: "fa fa-battery-full", suffix: ""}
                         ]

--- a/node_helper.js
+++ b/node_helper.js
@@ -127,7 +127,7 @@ module.exports = NodeHelper.create({
       json: params
     };
     if(config.hassiotoken) {
-      post_options.headers = { 'Authorization' : 'Bearer ' + process.env.HASSIO_TOKEN };
+      post_options.headers = { 'Authorization' : 'Bearer ' + config.token };
     }
 
     var post_req = request(post_options, function(error, response, body) {
@@ -173,7 +173,7 @@ module.exports = NodeHelper.create({
           json: true
         };
         if(config.hassiotoken) {
-          get_options.headers = { 'Authorization' : 'Bearer ' + process.env.HASSIO_TOKEN };
+          get_options.headers = { 'Authorization' : 'Bearer ' + config.token };
         }
         request(get_options, function(error, response, body) {
           completed_requests++;


### PR DESCRIPTION
I find it simpler to define the home assistant access token in the module config file.

This updates the node_helper.js code to get the token from the config file and updates the readme.md to show the token in the config.js